### PR TITLE
Use custom health check

### DIFF
--- a/TestEnvironmentTool/Commands/InitializeDatabaseCommand.cs
+++ b/TestEnvironmentTool/Commands/InitializeDatabaseCommand.cs
@@ -7,17 +7,17 @@ namespace TestEnvironmentTool.Commands
     [Verb("init", HelpText = "Initialize database container.")]
     public class InitializeDatabaseCommand : BaseCommand
     {
-        public Task<int> Execute(DatabaseContainerFactory databaseContainerFactory)
+        public async Task<int> Execute(DatabaseContainerFactory databaseContainerFactory)
         {
-            var result = TryExecute(
-                () =>
+            var result = await TryExecuteAsync(
+                async () =>
                 {
-                    var container = databaseContainerFactory.GetContainer();
+                    _ = databaseContainerFactory.GetContainer();
 
-                    databaseContainerFactory.WaitForHealthyDatabase(container);
+                    await databaseContainerFactory.DatabaseHealthCheck();
                 });
 
-            return Task.FromResult(result);
+            return result;
         }
     }
 }

--- a/TestEnvironmentTool/Infrastructure/SchemaPullManager.cs
+++ b/TestEnvironmentTool/Infrastructure/SchemaPullManager.cs
@@ -47,7 +47,7 @@ namespace TestEnvironmentTool.Infrastructure
                 .DefineImage(_settings.CustomPythonImageName)
                 .ReuseIfAlreadyExists()
                 .From(_settings.PythonImageTag)
-                .Run("echo 'deb http://ftp.us.debian.org/debian/ jessie main' >>/etc/apt/sources.list")
+                .Run("echo 'deb http://ftp.us.debian.org/debian/ jessie main' >> /etc/apt/sources.list")
                 .Run("apt-get update --allow-insecure-repositories")
                 .Run("apt-get install --allow-unauthenticated -y libicu63 libssl1.0.0 libffi-dev libunwind8")
                 .Run("pip install --upgrade pip")


### PR DESCRIPTION
- Removed FluentDocker health check that would verify the existence of a string in the container logs
- Replaced health check with a custom one that will retry to connect directly to the database from the environment tool